### PR TITLE
Fixed new selector .rc -> .tF2Cxc

### DIFF
--- a/userscript.js
+++ b/userscript.js
@@ -67,9 +67,15 @@
     var bettered = false;
 
     var runBetterGoogle = function() {
-        if (prevResultCount != document.querySelectorAll('.g .rc').length) {
-            document.querySelectorAll('.g .rc').forEach(betterGoogleRow);
-            prevResultCount = document.querySelectorAll('.g .rc').length;
+        const selectors = [ '.g .rc', '.g .tF2Cxc' ];
+        for (const selector of selectors) {
+            if (prevResultCount != document.querySelectorAll(selector).length) {
+                document.querySelectorAll(selector).forEach(betterGoogleRow);
+                prevResultCount = document.querySelectorAll(selector).length;
+            }
+            if (prevResultCount != 0) {
+                break;
+            }
         }
         if ( !bettered ) {
             if ( MutationObserver != undefined ) {


### PR DESCRIPTION
Google is randomly seeding the results with selectors named .rc and .tF2Cxc, the rollout seems to be random.
This change adds code to iterate through a list of hardcoded selectors and look for the correct selector.
There may be a more elegant and adaptive way of doing this, but this works presently, though it will need periodic updating when they break it.